### PR TITLE
Char eater fixed when redir glued to arg

### DIFF
--- a/srcs/parsing/nigga-tests.c
+++ b/srcs/parsing/nigga-tests.c
@@ -6,7 +6,7 @@
 /*   By: rgeral <rgeral@student.42lyon.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/04/19 15:08:12 by tgriffit          #+#    #+#             */
-/*   Updated: 2022/10/07 18:15:24 by tgriffit         ###   ########.fr       */
+/*   Updated: 2022/10/10 13:43:17 by tgriffit         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -46,7 +46,7 @@ int	main(int argc, char *argv[], char	*env[])
 			if (are_args_ok(args, nb_args))
 				exec_home(args, nb_args, &data);
 		}
-		free_t_argmode(args, nb_args);
+		//free_t_argmode(args, nb_args);
 		free(commandline);
 	}
 	free_env(nb_args, data);

--- a/srcs/parsing/parse_redirecs.c
+++ b/srcs/parsing/parse_redirecs.c
@@ -6,7 +6,7 @@
 /*   By: tgriffit <tgriffit@student.42.fr>          +#+  +:+       +#+        */
 /*                                                +#+#+#+#+#+   +#+           */
 /*   Created: 2022/05/03 17:38:42 by tgriffit          #+#    #+#             */
-/*   Updated: 2022/10/06 18:26:42 by tgriffit         ###   ########.fr       */
+/*   Updated: 2022/10/10 13:43:55 by tgriffit         ###   ########.fr       */
 /*                                                                            */
 /* ************************************************************************** */
 
@@ -110,7 +110,7 @@ t_argmode	*create_targmode_array(char *cmdline)
 	{
 		if (ft_check_redir(&cmdline[i], cmdline) != 0)
 		{
-			res[num_part].arg = ft_strndup(&cmdline[j], i - j - 1);
+			res[num_part].arg = ft_strndup(&cmdline[j], i - j);
 			res[num_part].mode = ft_check_redir(&cmdline[i], cmdline);
 			j = i + (res[num_part].mode == 3 || res[num_part].mode == 5) + 1;
 			num_part++;


### PR DESCRIPTION
Tried to debug the "[->]", it wasn't my bug but I fixed an other bug:
SENT:
```BASH
ls>a
```
RECEIVED
```BASH
l>a
```

[FIXED]