### PR TITLE
Improved historic + crash improvement

### DIFF
--- a/srcs/parsing/check_cmdline.c
+++ b/srcs/parsing/check_cmdline.c
@@ -71,6 +71,7 @@ static bool	is_chars_orgy(char *cmdline)
 bool	is_cmdline_ok(char **cmdline, char **env)
 {
 	char	*testcmd;
+	int		redir;
 
 	testcmd = ft_strtrim(*cmdline, " ");
 	if (!*testcmd)
@@ -80,9 +81,12 @@ bool	is_cmdline_ok(char **cmdline, char **env)
 	}
 	free(*cmdline);
 	*cmdline = testcmd;
+	redir = ft_check_redir(*cmdline, *cmdline);
 	if (!are_quotes_closed(*cmdline) || !are_slashs_ok(*cmdline))
 		return (false);
-	if (is_chars_orgy(*cmdline))
+	if (is_chars_orgy(*cmdline) \
+	|| ((redir == 2 || redir == 4) && ft_strlen(*cmdline) < 2) \
+	|| ((redir == 3) && ft_strlen(*cmdline) < 3))
 	{
 		printf(ERR_SYNTAX"\n");
 		return (false);

--- a/srcs/parsing/nigga-tests.c
+++ b/srcs/parsing/nigga-tests.c
@@ -25,6 +25,7 @@ size_t	parse_and_execute(char *commandline, t_args *data)
 	size_t		nb_args;
 	t_argmode	*args;
 
+	add_history(commandline);
 	args = create_targmode_array(commandline);
 	nb_args = 0;
 	while (args[nb_args].arg)
@@ -55,14 +56,13 @@ int	main(int argc, char *argv[], char	*env[])
 		sign_chars_manager(true);
 		if (!commandline)
 			break ;
-		add_history(commandline);
 		//rl_redisplay();
 		if (*commandline && is_cmdline_ok(&commandline, data.env))
 			nb_args = parse_and_execute(commandline, &data);
 		else
 			free(commandline);
 	}
-	puts("CONCHITO has exit the work place");
+	printf("CONCHITO has exit the work place\n");
 	free_env(nb_args, data);
 	clear_history();
 }


### PR DESCRIPTION
There's no more empty lines in the command lines' historic + no more crash with only "" and ">" and ">>" in the command line